### PR TITLE
update Spark lesson2、lesson3

### DIFF
--- a/1738-Spark 实例应用开发/420-数据库及表的创建.md
+++ b/1738-Spark 实例应用开发/420-数据库及表的创建.md
@@ -290,17 +290,13 @@ try {
 
 #### 概述
 
-Spark SQL 支持通过 SQL API 在 Spark 中建表并映射外部数据源，只要在 Spark 中创建了外部数据源的映射表，就可以通过 JDBC 访问映射表来达到操作外部数据源的目的。
-
-在 Spark 中创建 SequoiaDB 集合空间 employee 的映射表时需要使用 SequoiaDB 的 Spark 连接驱动（连接驱动可以在[巨杉数据库下载中心](http://download.sequoiadb.com/cn/driver)下载）。如果想要在 Spark 的 Spark-shell 或 beeline 等命令行工具使用 SQL API 创建 SequoiaDB 集合的映射表，需要确保 SPARK_CLASSPATH 中已添加连接驱动。
-
 在 Spark 中创建 SequoiaDB 集合的映射表需要指定映射目标集合所在的集合空间名、集合名以及 SequoiaDB 的数据库用户名和密码。若源表中已有数据，则无需定义表结构，在映射时 Spark 会根据结构化数据源自动生成表结构。
 
 建表语法及参数说明如下（详见[巨杉官方文档](http://doc.sequoiadb.com/cn/sequoiadb-cat_id-1432190712-edition_id-0)）：
 
 > CREATE TABLE employee
 >
-> USING com.sequoiadb.spark       -- SequoiaDB 的 Spark 连接驱动
+> USING com.sequoiadb.spark       -- 使用 SequoiaDB 的 Spark 连接驱动
 >
 > OPTIONS(
 >

--- a/1738-Spark 实例应用开发/430-数据类型.md
+++ b/1738-Spark 实例应用开发/430-数据类型.md
@@ -112,7 +112,7 @@ pom.xml 文件位置：
 >
 >  ArrayType array<int>,
 >
->  StructType struct<key:int,val:array<int>>
+>  StructType struct < key:int , val:array<int> >
 >
 > ) USING com.sequoiadb.spark                                 -- 使用 SequoiaDB 的 Spark 连接驱动
 >


### PR DESCRIPTION
删除在 Spark Classpath 下添加 SequoiaDB 的 Spark 连接器以在 SQL 命令行创建映射表的描述